### PR TITLE
Integrate asyncpg for PostgreSQL and remove psycopg2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ BigQuery → ETL Pipeline → Redis Cache → FastAPI → React Dashboard
 ## 🎯 Stack Tecnológico
 
 - **FastAPI** - API REST con OpenAPI automático
-- **Redis** - Cache de consultas frecuentes  
-- **PostgreSQL** - Storage para ETL
-- **BigQuery** - Source of truth
+- **Redis** - Cache de consultas frecuentes
+- **PostgreSQL (asyncpg)** - Storage para ETL (acceso con `asyncpg`)
+- **BigQuery (`google-cloud-bigquery`)** - Source of truth (acceso directo con cliente oficial)
 - **Docker** - Containerización
 - **Traefik** - Reverse proxy
 - **Celery** - Job scheduling
@@ -94,7 +94,9 @@ GET  /docs                 # OpenAPI docs
 Integrado con tu stack existente:
 - **Traefik** - Routing automático
 - **Redis** - Reutiliza tu instancia
-- **PostgreSQL** - Nuevo servicio
+- **PostgreSQL** - Nuevo servicio (usando `asyncpg`, no `psycopg2`)
+
+**Nota importante sobre dependencias de base de datos:** El backend solo usa BigQuery (via `google-cloud-bigquery`) y PostgreSQL (via `asyncpg`). No hay dependencia de `psycopg2` ni de SQLAlchemy para el acceso en tiempo de ejecución a PostgreSQL. SQLAlchemy puede seguir usándose para migraciones con Alembic si es necesario.
 
 ## 📊 Monitoring
 

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,81 +1,78 @@
 """
 🗄️ Database connection and session management
-SQLAlchemy setup with async support
+This file is being refactored to remove SQLAlchemy's direct async PostgreSQL integration
+in favor of a direct asyncpg service.
+SQLAlchemy might still be used for other purposes (e.g., migrations with Alembic, or other DB types).
 """
 
 import logging
 from typing import AsyncGenerator
 
-from sqlalchemy import create_engine, MetaData
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+# SQLAlchemy core components (potentially for Alembic or other DBs)
+from sqlalchemy import MetaData
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+
+# Asyncpg related imports will be in app.services.postgres_service.py
+# from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+# from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
-# Database URL conversion for async
-ASYNC_POSTGRES_URL = settings.POSTGRES_URL.replace("postgresql://", "postgresql+asyncpg://")
+# If SQLAlchemy is still needed for *PostgreSQL migrations via Alembic* but not for app runtime,
+# a synchronous engine might be configured here for Alembic.
+# For runtime, direct asyncpg will be used via PostgresService.
 
-# SQLAlchemy setup
-engine = create_async_engine(
-    ASYNC_POSTGRES_URL,
-    echo=settings.DEBUG,
-    pool_size=10,
-    max_overflow=20,
-    pool_pre_ping=True,
-    pool_recycle=3600,
-)
-
-AsyncSessionLocal = sessionmaker(
-    engine, class_=AsyncSession, expire_on_commit=False
-)
-
-# Base class for models
+# Base class for models (if using SQLAlchemy ORM with other DBs or for Alembic)
 Base = declarative_base()
-metadata = MetaData()
+metadata = MetaData() # Can be used by Alembic
+
+# The following SQLAlchemy async setup for PostgreSQL is being deprecated:
+# ASYNC_POSTGRES_URL = settings.POSTGRES_URL.replace("postgresql://", "postgresql+asyncpg://")
+# engine = create_async_engine(...)
+# AsyncSessionLocal = sessionmaker(...)
+
+# The get_db dependency for SQLAlchemy async sessions is removed.
+# If you need a PostgreSQL connection, you'll use the PostgresService.
+# async def get_db() -> AsyncGenerator[AsyncSession, None]: ...
+
+# The init_db function for creating tables via SQLAlchemy is removed.
+# Database schema management should ideally be handled by migrations (e.g., Alembic).
+# async def init_db() -> None: ...
+
+# The close_db function for SQLAlchemy engine is removed.
+# Connections via asyncpg will be managed by the PostgresService.
+# async def close_db() -> None: ...
 
 
-async def get_db() -> AsyncGenerator[AsyncSession, None]:
-    """
-    Dependency to get database session
-    """
-    async with AsyncSessionLocal() as session:
-        try:
-            yield session
-        except Exception as e:
-            logger.error(f"Database session error: {e}")
-            await session.rollback()
-            raise
-        finally:
-            await session.close()
+# Example: If Alembic needs to generate migrations based on SQLAlchemy models,
+# it might require a synchronous engine. This is typically configured in Alembic's env.py
+# from sqlalchemy import create_engine
+# SQLALCHEMY_DATABASE_URL = settings.POSTGRES_URL # Standard URL for sync Alembic
+# alembic_engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
+# For now, this file will primarily hold the Base and metadata if models are defined
+# using SQLAlchemy's declarative system, which Alembic can use.
 
-async def init_db() -> None:
-    """
-    Initialize database tables
-    """
-    try:
-        async with engine.begin() as conn:
-            # Import all models here to ensure they are registered
-            from app.models import dashboard, evolution, assignment  # noqa
-            
-            # Create all tables
-            await conn.run_sync(Base.metadata.create_all)
-            logger.info("Database tables created successfully")
-            
-    except Exception as e:
-        logger.error(f"Failed to initialize database: {e}")
-        raise
+# If models are not using SQLAlchemy (e.g. Pydantic models for BigQuery/asyncpg results),
+# then Base and metadata might also be removed if Alembic is not used or configured differently.
+# For this refactor, we assume Alembic might still be in use, so Base and metadata are kept.
 
+logger.info("database.py: SQLAlchemy async setup for PostgreSQL has been removed. "
+            "Direct asyncpg via PostgresService should be used for runtime PostgreSQL operations. "
+            "SQLAlchemy Base and metadata are kept for potential Alembic use.")
 
-async def close_db() -> None:
-    """
-    Close database connections
-    """
-    try:
-        await engine.dispose()
-        logger.info("Database connections closed")
-    except Exception as e:
-        logger.error(f"Error closing database: {e}")
+# To ensure models are registered with metadata if Base is used by them:
+# from app.models import dashboard, evolution, assignment # noqa
+# This line would typically be within init_db or similar, or just by virtue of models importing Base.
+# If your models in app.models.* import Base from here, they get registered.
+
+# placeholder for any future synchronous engine needed by Alembic, not for runtime
+alembic_engine = None
+if settings.DATA_SOURCE_TYPE == "postgresql" and settings.POSTGRES_URL:
+    # This is a placeholder. Alembic's env.py is the primary place for its engine config.
+    # from sqlalchemy import create_engine
+    # logger.info("Creating synchronous SQLAlchemy engine for potential Alembic use.")
+    # alembic_engine = create_engine(settings.POSTGRES_URL.replace("+asyncpg", "")) # Ensure it's a sync URL
+    pass

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -6,11 +6,12 @@ Este archivo es la única fuente de la verdad para crear y proveer dependencias 
 """
 from typing import Generator, Annotated
 from fastapi import Depends
-from sqlalchemy.ext.asyncio import AsyncSession
 import redis.asyncio as redis
+# from sqlalchemy.ext.asyncio import AsyncSession # No longer needed for get_db_session
 
 # --- Importamos las piezas básicas de nuestros módulos core ---
-from app.core.database import get_db as get_db_session  # Renombramos para claridad
+# from app.core.database import get_db as get_db_session # This is removed
+from app.services.postgres_service import PostgresService # Import new service
 from app.core.cache import cache as redis_cache_manager
 from app.repositories.data_adapters import DataSourceFactory, DataSourceAdapter
 from app.services.dashboard_service_v2 import DashboardServiceV2
@@ -38,7 +39,17 @@ def get_data_adapter() -> DataSourceAdapter:
 
 # Usamos Annotated para una sintaxis más limpia y un mejor chequeo de tipos.
 # Es la forma moderna y recomendada de usar Depends.
-DBSession = Annotated[AsyncSession, Depends(get_db_session)]
+# DBSession = Annotated[AsyncSession, Depends(get_db_session)] # This is removed
+
+# Dependency for the new PostgresService
+async def get_postgres_service() -> PostgresService:
+    """
+    Provee una instancia de PostgresService.
+    La configuración DSN es manejada dentro del servicio.
+    """
+    return PostgresService()
+
+PostgresDB = Annotated[PostgresService, Depends(get_postgres_service)]
 RedisClient = Annotated[redis.Redis, Depends(get_redis_client)]
 DataAdapter = Annotated[DataSourceAdapter, Depends(get_data_adapter)]
 

--- a/app/services/postgres_service.py
+++ b/app/services/postgres_service.py
@@ -1,0 +1,156 @@
+import asyncpg
+import asyncio
+import logging
+from typing import Optional, List, Dict, Any
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+class PostgresService:
+    def __init__(self, dsn: Optional[str] = None):
+        self.dsn = dsn or settings.POSTGRES_URL
+        if not self.dsn:
+            raise ValueError("PostgreSQL DSN must be configured via POSTGRES_URL environment variable.")
+        # Ensure the DSN is compatible with asyncpg (postgresql://...)
+        if self.dsn.startswith("postgresql+asyncpg://"):
+            logger.warning("DSN starts with postgresql+asyncpg://, converting to postgresql:// for asyncpg direct use.")
+            self.dsn = self.dsn.replace("postgresql+asyncpg://", "postgresql://")
+
+    async def _get_connection(self):
+        try:
+            conn = await asyncpg.connect(dsn=self.dsn)
+            logger.info(f"Successfully connected to PostgreSQL: {self.dsn.split('@')[-1]}")
+            return conn
+        except Exception as e:
+            logger.error(f"Failed to connect to PostgreSQL: {e}")
+            raise
+
+    async def fetch(self, query: str, *params: Any) -> List[asyncpg.Record]:
+        """
+        Executes a query and returns a list of records.
+        """
+        conn = None
+        try:
+            conn = await self._get_connection()
+            return await conn.fetch(query, *params)
+        except Exception as e:
+            logger.error(f"Error executing fetch query: {e}. Query: {query[:200]}", exc_info=True)
+            raise
+        finally:
+            if conn:
+                await conn.close()
+
+    async def fetchrow(self, query: str, *params: Any) -> Optional[asyncpg.Record]:
+        """
+        Executes a query and returns a single record or None.
+        """
+        conn = None
+        try:
+            conn = await self._get_connection()
+            return await conn.fetchrow(query, *params)
+        except Exception as e:
+            logger.error(f"Error executing fetchrow query: {e}. Query: {query[:200]}", exc_info=True)
+            raise
+        finally:
+            if conn:
+                await conn.close()
+
+    async def fetchval(self, query: str, *params: Any) -> Any:
+        """
+        Executes a query and returns a single value from the first record.
+        """
+        conn = None
+        try:
+            conn = await self._get_connection()
+            return await conn.fetchval(query, *params)
+        except Exception as e:
+            logger.error(f"Error executing fetchval query: {e}. Query: {query[:200]}", exc_info=True)
+            raise
+        finally:
+            if conn:
+                await conn.close()
+
+    async def execute(self, query: str, *params: Any) -> str:
+        """
+        Executes a query (e.g., INSERT, UPDATE, DELETE) and returns the status.
+        """
+        conn = None
+        try:
+            conn = await self._get_connection()
+            return await conn.execute(query, *params)
+        except Exception as e:
+            logger.error(f"Error executing execute query: {e}. Query: {query[:200]}", exc_info=True)
+            raise
+        finally:
+            if conn:
+                await conn.close()
+
+    async def health_check(self) -> bool:
+        """
+        Performs a simple health check on the PostgreSQL connection.
+        Returns True if successful, False otherwise.
+        """
+        try:
+            val = await self.fetchval("SELECT 1")
+            return val == 1
+        except Exception as e:
+            logger.error(f"PostgreSQL health check failed: {e}")
+            return False
+
+# Example usage (can be removed or moved to tests)
+async def example_get_user_by_id(user_id: int):
+    pg_service = PostgresService()
+    # Ensure DSN is correctly configured in your environment for this example to run
+    if not pg_service.dsn:
+        logger.warning("Skipping example_get_user_by_id: POSTGRES_URL not configured.")
+        return None
+
+    logger.info(f"Attempting to fetch user with ID: {user_id} using DSN: {pg_service.dsn}")
+    try:
+        # Example: Fetching a user by ID
+        # Replace 'users' and 'id' with your actual table and column names
+        # Ensure you have a 'users' table with an 'id' column for this example
+        # user_record = await pg_service.fetchrow("SELECT * FROM users WHERE id = $1", user_id)
+
+        # For testing without a real users table, let's try a simple query
+        time_record = await pg_service.fetchrow("SELECT NOW() as current_time;")
+        if time_record:
+            logger.info(f"PostgreSQL current time: {time_record['current_time']}")
+            return time_record
+        else:
+            logger.warning(f"No record found for example query.")
+            return None
+
+    except Exception as e:
+        logger.error(f"Error in example_get_user_by_id: {e}")
+        return None
+
+if __name__ == "__main__":
+    # This is for standalone testing of the service
+    # You'll need to have your .env file or environment variables set up
+    # e.g., POSTGRES_URL=postgresql://user:pass@host/db
+
+    async def main():
+        # Check if DSN is available
+        if not settings.POSTGRES_URL:
+            print("POSTGRES_URL is not set. Skipping PostgreSQL service example.")
+            return
+
+        print(f"Running PostgresService example with DSN: {settings.POSTGRES_URL}")
+
+        # Example: Fetch current time (or a user if you have a users table)
+        record = await example_get_user_by_id(1)
+        if record:
+            print("Example query successful. Record:", dict(record))
+        else:
+            print("Example query failed or returned no record.")
+
+        # Test health check
+        pg_service = PostgresService()
+        is_healthy = await pg_service.health_check()
+        print(f"PostgreSQL health check: {'OK' if is_healthy else 'Failed'}")
+
+    # Setup basic logging for the example
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/app/tests/__init__.py
+++ b/app/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the `tests` directory as a package.

--- a/app/tests/test_postgres_service.py
+++ b/app/tests/test_postgres_service.py
@@ -1,0 +1,234 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import patch, AsyncMock
+
+from app.services.postgres_service import PostgresService
+from app.core.config import settings
+
+# Set a test DSN or ensure your environment provides one for testing
+# For example, by setting POSTGRES_URL in a .env.test file loaded by pytest-dotenv
+# or by mocking settings directly if preferred.
+TEST_POSTGRES_DSN = settings.POSTGRES_URL or "postgresql://testuser:testpass@testhost/testdb"
+
+@pytest.fixture
+def service():
+    """Fixture to create a PostgresService instance for testing."""
+    # It's good practice to ensure a test-specific DSN is used if possible.
+    # If settings.POSTGRES_URL is not set, this will use the default test DSN.
+    return PostgresService(dsn=TEST_POSTGRES_DSN)
+
+@pytest_asyncio.fixture
+async def mock_asyncpg_connect():
+    """Mocks asyncpg.connect and the connection object."""
+    with patch("asyncpg.connect", new_callable=AsyncMock) as mock_connect:
+        mock_conn = AsyncMock()
+        mock_connect.return_value = mock_conn
+
+        # Mock connection methods
+        mock_conn.fetch = AsyncMock()
+        mock_conn.fetchrow = AsyncMock()
+        mock_conn.fetchval = AsyncMock()
+        mock_conn.execute = AsyncMock()
+        mock_conn.close = AsyncMock()
+        yield mock_connect, mock_conn
+
+@pytest.mark.asyncio
+async def test_postgres_service_init_with_dsn(service):
+    assert service.dsn == TEST_POSTGRES_DSN
+
+@pytest.mark.asyncio
+async def test_postgres_service_init_no_dsn_raises_error():
+    original_url = settings.POSTGRES_URL
+    settings.POSTGRES_URL = None # Temporarily unset
+    with pytest.raises(ValueError, match="PostgreSQL DSN must be configured"):
+        PostgresService()
+    settings.POSTGRES_URL = original_url # Restore
+
+@pytest.mark.asyncio
+async def test_fetch_successful(service, mock_asyncpg_connect):
+    mock_connect, mock_conn = mock_asyncpg_connect
+    mock_conn.fetch.return_value = [{"id": 1, "name": "Test"}]
+
+    query = "SELECT * FROM test_table"
+    result = await service.fetch(query, 123)
+
+    mock_connect.assert_called_once_with(dsn=TEST_POSTGRES_DSN)
+    mock_conn.fetch.assert_called_once_with(query, 123)
+    mock_conn.close.assert_called_once()
+    assert result == [{"id": 1, "name": "Test"}]
+
+@pytest.mark.asyncio
+async def test_fetchrow_successful(service, mock_asyncpg_connect):
+    mock_connect, mock_conn = mock_asyncpg_connect
+    mock_conn.fetchrow.return_value = {"id": 1, "name": "Test"}
+
+    query = "SELECT * FROM test_table WHERE id = $1"
+    param = 1
+    result = await service.fetchrow(query, param)
+
+    mock_connect.assert_called_once_with(dsn=TEST_POSTGRES_DSN)
+    mock_conn.fetchrow.assert_called_once_with(query, param)
+    mock_conn.close.assert_called_once()
+    assert result == {"id": 1, "name": "Test"}
+
+@pytest.mark.asyncio
+async def test_fetchval_successful(service, mock_asyncpg_connect):
+    mock_connect, mock_conn = mock_asyncpg_connect
+    mock_conn.fetchval.return_value = 123
+
+    query = "SELECT COUNT(*) FROM test_table"
+    result = await service.fetchval(query)
+
+    mock_connect.assert_called_once_with(dsn=TEST_POSTGRES_DSN)
+    mock_conn.fetchval.assert_called_once_with(query)
+    mock_conn.close.assert_called_once()
+    assert result == 123
+
+@pytest.mark.asyncio
+async def test_execute_successful(service, mock_asyncpg_connect):
+    mock_connect, mock_conn = mock_asyncpg_connect
+    mock_conn.execute.return_value = "INSERT 0 1"
+
+    query = "INSERT INTO test_table (name) VALUES ($1)"
+    param = "New Value"
+    result = await service.execute(query, param)
+
+    mock_connect.assert_called_once_with(dsn=TEST_POSTGRES_DSN)
+    mock_conn.execute.assert_called_once_with(query, param)
+    mock_conn.close.assert_called_once()
+    assert result == "INSERT 0 1"
+
+@pytest.mark.asyncio
+async def test_health_check_healthy(service, mock_asyncpg_connect):
+    mock_connect, mock_conn = mock_asyncpg_connect
+    mock_conn.fetchval.return_value = 1 # Simulate SELECT 1 returning 1
+
+    is_healthy = await service.health_check()
+
+    mock_connect.assert_called_once_with(dsn=TEST_POSTGRES_DSN)
+    mock_conn.fetchval.assert_called_once_with("SELECT 1")
+    mock_conn.close.assert_called_once()
+    assert is_healthy is True
+
+@pytest.mark.asyncio
+async def test_health_check_unhealthy_value_mismatch(service, mock_asyncpg_connect):
+    mock_connect, mock_conn = mock_asyncpg_connect
+    mock_conn.fetchval.return_value = 0 # Simulate SELECT 1 returning something else
+
+    is_healthy = await service.health_check()
+
+    mock_connect.assert_called_once_with(dsn=TEST_POSTGRES_DSN)
+    assert is_healthy is False
+
+@pytest.mark.asyncio
+async def test_health_check_exception(service, mock_asyncpg_connect):
+    mock_connect, mock_conn = mock_asyncpg_connect
+    mock_conn.fetchval.side_effect = Exception("Connection error")
+
+    is_healthy = await service.health_check()
+
+    mock_connect.assert_called_once_with(dsn=TEST_POSTGRES_DSN)
+    assert is_healthy is False # Should catch exception and return False
+
+@pytest.mark.asyncio
+async def test_connection_failure_raises_and_logs(service, mock_asyncpg_connect):
+    mock_connect, _ = mock_asyncpg_connect
+    mock_connect.side_effect = Exception("Failed to connect")
+
+    with patch("app.services.postgres_service.logger.error") as mock_logger_error:
+        with pytest.raises(Exception, match="Failed to connect"):
+            await service.fetch("SELECT 1")
+        mock_logger_error.assert_called_once()
+        # Check that the error message contains "Failed to connect to PostgreSQL"
+        args, _ = mock_logger_error.call_args
+        assert "Failed to connect to PostgreSQL" in args[0]
+
+
+@pytest.mark.asyncio
+async def test_query_method_exception_logs_and_raises(service, mock_asyncpg_connect):
+    mock_connect, mock_conn = mock_asyncpg_connect
+
+    # Test for fetch
+    mock_conn.fetch.side_effect = Exception("Query execution error for fetch")
+    with patch("app.services.postgres_service.logger.error") as mock_logger_error:
+        with pytest.raises(Exception, match="Query execution error for fetch"):
+            await service.fetch("SELECT * FROM table")
+        mock_logger_error.assert_called_once()
+        args, _ = mock_logger_error.call_args
+        assert "Error executing fetch query" in args[0]
+        assert "SELECT * FROM table" in args[0]
+
+    mock_conn.close.assert_called_once() # Ensure close is called even on error
+    mock_conn.reset_mock() # Reset for next call
+    mock_connect.reset_mock()
+
+    # Test for fetchrow
+    mock_conn.fetchrow.side_effect = Exception("Query execution error for fetchrow")
+    with patch("app.services.postgres_service.logger.error") as mock_logger_error:
+        with pytest.raises(Exception, match="Query execution error for fetchrow"):
+            await service.fetchrow("SELECT * FROM table_row")
+        mock_logger_error.assert_called_once()
+        args, _ = mock_logger_error.call_args
+        assert "Error executing fetchrow query" in args[0]
+        assert "SELECT * FROM table_row" in args[0]
+
+    mock_conn.close.assert_called_once()
+    mock_conn.reset_mock()
+    mock_connect.reset_mock()
+
+    # Test for fetchval
+    mock_conn.fetchval.side_effect = Exception("Query execution error for fetchval")
+    with patch("app.services.postgres_service.logger.error") as mock_logger_error:
+        with pytest.raises(Exception, match="Query execution error for fetchval"):
+            await service.fetchval("SELECT val FROM table_val")
+        mock_logger_error.assert_called_once()
+        args, _ = mock_logger_error.call_args
+        assert "Error executing fetchval query" in args[0]
+        assert "SELECT val FROM table_val" in args[0]
+
+    mock_conn.close.assert_called_once()
+    mock_conn.reset_mock()
+    mock_connect.reset_mock()
+
+    # Test for execute
+    mock_conn.execute.side_effect = Exception("Query execution error for execute")
+    with patch("app.services.postgres_service.logger.error") as mock_logger_error:
+        with pytest.raises(Exception, match="Query execution error for execute"):
+            await service.execute("INSERT SOMETHING")
+        mock_logger_error.assert_called_once()
+        args, _ = mock_logger_error.call_args
+        assert "Error executing execute query" in args[0]
+        assert "INSERT SOMETHING" in args[0]
+
+    mock_conn.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dsn_conversion_from_sqlalchemy_asyncpg_format(mock_asyncpg_connect):
+    """
+    Tests that if a DSN like 'postgresql+asyncpg://...' is passed, it's converted
+    to 'postgresql://...' for asyncpg.connect.
+    """
+    mock_connect, _ = mock_asyncpg_connect
+    sqlalchemy_dsn = "postgresql+asyncpg://user:pass@host/db"
+    expected_asyncpg_dsn = "postgresql://user:pass@host/db"
+
+    with patch("app.services.postgres_service.logger.warning") as mock_logger_warning:
+        service_with_conversion = PostgresService(dsn=sqlalchemy_dsn)
+        assert service_with_conversion.dsn == expected_asyncpg_dsn
+        mock_logger_warning.assert_called_once()
+        args, _ = mock_logger_warning.call_args
+        assert "DSN starts with postgresql+asyncpg://" in args[0]
+
+    # Ensure it still calls connect with the corrected DSN
+    await service_with_conversion.fetch("SELECT 1")
+    mock_connect.assert_called_once_with(dsn=expected_asyncpg_dsn)
+
+# It's good practice to also test if existing BigQuery tests need updates,
+# but that's outside the scope of this specific file.
+# For example, ensure that `app/tests/test_bigquery_repo.py` exists and is comprehensive.
+# This task focuses on adding tests for the new `PostgresService`.
+# Placeholder for BigQuery tests (assuming they exist elsewhere or will be added):
+# from app.repositories.bigquery_repo import BigQueryRepository # etc.
+# async def test_bigquery_repo_health_check(): ...
+# async def test_bigquery_repo_queries(): ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "python-multipart>=0.0.19", # Necesario para subida de archivos en FastAPI
     # Database & Cache
-    "psycopg2-binary>=2.9.9",
+    # "psycopg2-binary>=2.9.9", # Replaced by asyncpg
     "redis>=5.0.1",
-    "sqlalchemy>=2.0.23",
-    "alembic>=1.13.1",
+    "sqlalchemy>=2.0.23", # Keep for now, may be removed if not used by anything else
+    "alembic>=1.13.1", # Keep for now, may be removed if not used by anything else
     # Google Cloud
     "google-cloud-bigquery>=3.13.0",
     "google-cloud-storage>=2.10.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,13 @@ uvicorn[standard]==0.24.0
 starlette==0.40.0
 
 # Database & Cache
-psycopg2-binary==2.9.9
+asyncpg==0.29.0  # Added asyncpg
 redis==5.0.1
-sqlalchemy==2.0.23
-alembic==1.13.1
+sqlalchemy==2.0.23 # Keep for potential ORM use with other DBs or if parts of it are still used
+alembic==1.13.1 # Keep for migrations if SQLAlchemy is still partially used
 
 # Google Cloud & BigQuery
-google-cloud-bigquery==3.13.0
+google-cloud-bigquery==3.13.0 # Already present
 google-cloud-storage==2.10.0
 google-auth==2.23.4
 


### PR DESCRIPTION
- Replaced psycopg2-binary with asyncpg in requirements.
- Created PostgresService (app/services/postgres_service.py) for asyncpg operations.
- Refactored app/core/database.py to remove SQLAlchemy's async PostgreSQL engine, keeping Base and metadata for potential Alembic use.
- Updated app/core/dependencies.py to use PostgresService instead of SQLAlchemy session for PostgreSQL.
- Added unit tests for PostgresService.
- Updated README.md to reflect the change in database drivers.
- Verified Docker configuration remains compatible.