### PR TITLE
feat: Add yoyo migrations for authentication models

### DIFF
--- a/migrations/019-create-roles-table.sql
+++ b/migrations/019-create-roles-table.sql
@@ -1,0 +1,46 @@
+-- Create roles table
+-- Stores user roles for role-based access control (RBAC).
+-- Ensures that critical system roles cannot be accidentally deleted.
+
+CREATE TABLE IF NOT EXISTS roles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(50) UNIQUE NOT NULL,
+    display_name VARCHAR(100) NOT NULL,
+    description TEXT,
+    is_system BOOLEAN DEFAULT FALSE, -- Prevents deletion of critical roles
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    updated_by UUID REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Indexes for performance
+CREATE INDEX IF NOT EXISTS idx_roles_name_active ON roles (name, is_active);
+
+-- Trigger to update 'updated_at' timestamp on any row modification
+CREATE OR REPLACE FUNCTION update_roles_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_roles_updated_at
+BEFORE UPDATE ON roles
+FOR EACH ROW
+EXECUTE FUNCTION update_roles_updated_at_column();
+
+-- Comments for clarity
+COMMENT ON TABLE roles IS 'Stores user roles for role-based access control (RBAC).';
+COMMENT ON COLUMN roles.id IS 'Unique identifier for the role.';
+COMMENT ON COLUMN roles.name IS 'Unique internal name for the role (e.g., superadmin, analyst).';
+COMMENT ON COLUMN roles.display_name IS 'User-friendly display name for the role (e.g., Super Administrator).';
+COMMENT ON COLUMN roles.description IS 'Detailed description of the role and its responsibilities.';
+COMMENT ON COLUMN roles.is_system IS 'Flag to indicate if the role is a system-critical role (prevents deletion).';
+COMMENT ON COLUMN roles.is_active IS 'Flag to indicate if the role is currently active and usable.';
+COMMENT ON COLUMN roles.created_at IS 'Timestamp of when the role was created.';
+COMMENT ON COLUMN roles.updated_at IS 'Timestamp of when the role was last updated.';
+COMMENT ON COLUMN roles.created_by IS 'User ID of the creator of this role.';
+COMMENT ON COLUMN roles.updated_by IS 'User ID of the last user who updated this role.';

--- a/migrations/020-create-users-table.sql
+++ b/migrations/020-create-users-table.sql
@@ -1,0 +1,79 @@
+-- Create users table
+-- Stores user information, credentials, and status.
+-- Designed for secure authentication and detailed user management.
+
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    first_name VARCHAR(100) NOT NULL,
+    last_name VARCHAR(100) NOT NULL,
+    dni VARCHAR(20) UNIQUE,
+    phone VARCHAR(20),
+
+    -- Account status and security
+    status VARCHAR(20) NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'inactive', 'suspended')),
+    is_email_verified BOOLEAN DEFAULT FALSE,
+    email_verified_at TIMESTAMPTZ,
+
+    -- Role relationship
+    role_id UUID REFERENCES roles(id) ON DELETE RESTRICT NOT NULL , -- Prevent deleting role if users are assigned
+
+    -- Security tracking
+    last_login_at TIMESTAMPTZ,
+    last_login_ip VARCHAR(45), -- Supports IPv6
+    failed_login_attempts INTEGER DEFAULT 0,
+    locked_until TIMESTAMPTZ,
+    password_changed_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Audit fields
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    updated_by UUID REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Indexes for performance and common queries
+CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);
+CREATE INDEX IF NOT EXISTS idx_users_status ON users (status);
+CREATE INDEX IF NOT EXISTS idx_users_role_id ON users (role_id);
+CREATE INDEX IF NOT EXISTS idx_users_email_status ON users (email, status);
+CREATE INDEX IF NOT EXISTS idx_users_role_status ON users (role_id, status);
+CREATE INDEX IF NOT EXISTS idx_users_last_login ON users (last_login_at);
+
+-- Trigger to update 'updated_at' timestamp on any row modification
+CREATE OR REPLACE FUNCTION update_users_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_users_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION update_users_updated_at_column();
+
+-- Comments for clarity
+COMMENT ON TABLE users IS 'Stores user information, credentials, and status for authentication and authorization.';
+COMMENT ON COLUMN users.id IS 'Unique identifier for the user.';
+COMMENT ON COLUMN users.email IS 'Unique email address for the user, used for login.';
+COMMENT ON COLUMN users.password_hash IS 'Hashed password for secure storage.';
+COMMENT ON COLUMN users.first_name IS 'User''s first name.';
+COMMENT ON COLUMN users.last_name IS 'User''s last name.';
+COMMENT ON COLUMN users.dni IS 'User''s National Identity Document number (optional, unique).';
+COMMENT ON COLUMN users.phone IS 'User''s phone number (optional).';
+COMMENT ON COLUMN users.status IS 'Account status (active, inactive, suspended).';
+COMMENT ON COLUMN users.is_email_verified IS 'Flag indicating if the user''s email address has been verified.';
+COMMENT ON COLUMN users.email_verified_at IS 'Timestamp of when the email was verified.';
+COMMENT ON COLUMN users.role_id IS 'Foreign key referencing the user''s assigned role in the roles table.';
+COMMENT ON COLUMN users.last_login_at IS 'Timestamp of the user''s last successful login.';
+COMMENT ON COLUMN users.last_login_ip IS 'IP address from which the user last logged in.';
+COMMENT ON COLUMN users.failed_login_attempts IS 'Counter for consecutive failed login attempts.';
+COMMENT ON COLUMN users.locked_until IS 'Timestamp until which the account is locked due to failed attempts.';
+COMMENT ON COLUMN users.password_changed_at IS 'Timestamp of the last password change.';
+COMMENT ON COLUMN users.created_at IS 'Timestamp of when the user account was created.';
+COMMENT ON COLUMN users.updated_at IS 'Timestamp of when the user account was last updated.';
+COMMENT ON COLUMN users.created_by IS 'User ID of the creator of this user account.';
+COMMENT ON COLUMN users.updated_by IS 'User ID of the last user who updated this account.';

--- a/migrations/021-create-permissions-table.sql
+++ b/migrations/021-create-permissions-table.sql
@@ -1,0 +1,45 @@
+-- Create permissions table
+-- Stores granular permissions for actions on resources (e.g., 'user.read', 'dashboard.edit').
+-- Helps in defining precise access control for different roles.
+
+CREATE TABLE IF NOT EXISTS permissions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) UNIQUE NOT NULL, -- e.g., 'user.read', 'dashboard.edit'
+    resource VARCHAR(50) NOT NULL,     -- e.g., 'user', 'dashboard'
+    action VARCHAR(50) NOT NULL,      -- e.g., 'read', 'write', 'delete', 'edit'
+    description TEXT,
+    is_system BOOLEAN DEFAULT FALSE, -- Prevents deletion of critical permissions
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for performance
+CREATE INDEX IF NOT EXISTS idx_permissions_name_active ON permissions (name, is_active);
+CREATE INDEX IF NOT EXISTS idx_permissions_resource_action ON permissions (resource, action);
+
+-- Trigger to update 'updated_at' timestamp on any row modification
+CREATE OR REPLACE FUNCTION update_permissions_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_permissions_updated_at
+BEFORE UPDATE ON permissions
+FOR EACH ROW
+EXECUTE FUNCTION update_permissions_updated_at_column();
+
+-- Comments for clarity
+COMMENT ON TABLE permissions IS 'Stores granular permissions for actions on resources (e.g., user.read).';
+COMMENT ON COLUMN permissions.id IS 'Unique identifier for the permission.';
+COMMENT ON COLUMN permissions.name IS 'Unique name for the permission (e.g., user.read, dashboard.edit).';
+COMMENT ON COLUMN permissions.resource IS 'The resource this permission applies to (e.g., user, dashboard).';
+COMMENT ON COLUMN permissions.action IS 'The action allowed by this permission (e.g., read, write, delete).';
+COMMENT ON COLUMN permissions.description IS 'Detailed description of what this permission allows.';
+COMMENT ON COLUMN permissions.is_system IS 'Flag to indicate if the permission is system-critical (prevents deletion).';
+COMMENT ON COLUMN permissions.is_active IS 'Flag to indicate if the permission is currently active.';
+COMMENT ON COLUMN permissions.created_at IS 'Timestamp of when the permission was created.';
+COMMENT ON COLUMN permissions.updated_at IS 'Timestamp of when the permission was last updated.';

--- a/migrations/022-create-role-permissions-table.sql
+++ b/migrations/022-create-role-permissions-table.sql
@@ -1,0 +1,20 @@
+-- Create role_permissions table (Many-to-Many association)
+-- Links roles to permissions, defining what actions a role can perform.
+-- Ensures data integrity with foreign key constraints and cascading deletes.
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id UUID NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+    PRIMARY KEY (role_id, permission_id), -- Composite primary key
+    CONSTRAINT unique_role_permission UNIQUE (role_id, permission_id) -- Ensure unique pairings
+);
+
+-- Indexes for performance on join operations
+CREATE INDEX IF NOT EXISTS idx_role_permissions_role_id ON role_permissions (role_id);
+CREATE INDEX IF NOT EXISTS idx_role_permissions_permission_id ON role_permissions (permission_id);
+
+-- Comments for clarity
+COMMENT ON TABLE role_permissions IS 'Association table linking roles to their assigned permissions (Many-to-Many).';
+COMMENT ON COLUMN role_permissions.role_id IS 'Foreign key referencing the role.';
+COMMENT ON COLUMN role_permissions.permission_id IS 'Foreign key referencing the permission.';
+COMMENT ON CONSTRAINT unique_role_permission ON role_permissions IS 'Ensures that each role-permission assignment is unique.';

--- a/migrations/023-create-refresh-tokens-table.sql
+++ b/migrations/023-create-refresh-tokens-table.sql
@@ -1,0 +1,44 @@
+-- Create refresh_tokens table
+-- Stores JWT refresh tokens for persistent sessions and secure token management.
+-- Includes features for token rotation, revocation, and device tracking.
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash VARCHAR(255) UNIQUE NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+    -- Token metadata
+    expires_at TIMESTAMPTZ NOT NULL,
+    is_revoked BOOLEAN DEFAULT FALSE,
+    revoked_at TIMESTAMPTZ,
+    revoked_reason VARCHAR(100), -- e.g., 'logout', 'expired', 'security_breach'
+
+    -- Device/session tracking
+    device_info TEXT, -- User agent, device details
+    ip_address VARCHAR(45), -- Supports IPv6
+
+    -- Audit fields
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ
+);
+
+-- Indexes for performance and common queries
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token_hash ON refresh_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id ON refresh_tokens (user_id);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_valid ON refresh_tokens (user_id, is_revoked, expires_at);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_at ON refresh_tokens (expires_at);
+
+
+-- Comments for clarity
+COMMENT ON TABLE refresh_tokens IS 'Stores JWT refresh tokens for persistent user sessions and secure token management.';
+COMMENT ON COLUMN refresh_tokens.id IS 'Unique identifier for the refresh token.';
+COMMENT ON COLUMN refresh_tokens.token_hash IS 'Hashed version of the refresh token for secure storage.';
+COMMENT ON COLUMN refresh_tokens.user_id IS 'Foreign key referencing the user who owns this token.';
+COMMENT ON COLUMN refresh_tokens.expires_at IS 'Timestamp when the refresh token expires.';
+COMMENT ON COLUMN refresh_tokens.is_revoked IS 'Flag indicating if the token has been revoked (e.g., due to logout or security event).';
+COMMENT ON COLUMN refresh_tokens.revoked_at IS 'Timestamp when the token was revoked.';
+COMMENT ON COLUMN refresh_tokens.revoked_reason IS 'Reason for token revocation (e.g., logout, expired, security_breach).';
+COMMENT ON COLUMN refresh_tokens.device_info IS 'Information about the device or client that requested the token (e.g., user agent).';
+COMMENT ON COLUMN refresh_tokens.ip_address IS 'IP address from which the token was requested.';
+COMMENT ON COLUMN refresh_tokens.created_at IS 'Timestamp of when the refresh token was created.';
+COMMENT ON COLUMN refresh_tokens.last_used_at IS 'Timestamp of when the refresh token was last used.';

--- a/migrations/024-create-csrf-tokens-table.sql
+++ b/migrations/024-create-csrf-tokens-table.sql
@@ -1,0 +1,39 @@
+-- Create csrf_tokens table
+-- Stores CSRF tokens for protection against Cross-Site Request Forgery attacks.
+-- Implements a double submit cookie pattern with token rotation and expiration.
+
+CREATE TABLE IF NOT EXISTS csrf_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash VARCHAR(255) UNIQUE NOT NULL,
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE, -- Can be NULL for anonymous users
+
+    -- Token metadata
+    expires_at TIMESTAMPTZ NOT NULL,
+    is_used BOOLEAN DEFAULT FALSE,
+    used_at TIMESTAMPTZ,
+
+    -- Session tracking
+    session_id VARCHAR(255), -- Optional: Link to a specific session if applicable
+    ip_address VARCHAR(45),   -- Supports IPv6
+
+    -- Audit fields
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for performance
+CREATE INDEX IF NOT EXISTS idx_csrf_tokens_token_hash ON csrf_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS idx_csrf_tokens_user_id ON csrf_tokens (user_id);
+CREATE INDEX IF NOT EXISTS idx_csrf_tokens_expires_at ON csrf_tokens (expires_at);
+CREATE INDEX IF NOT EXISTS idx_csrf_tokens_user_valid ON csrf_tokens (user_id, expires_at, is_used);
+
+-- Comments for clarity
+COMMENT ON TABLE csrf_tokens IS 'Stores CSRF tokens for Cross-Site Request Forgery protection.';
+COMMENT ON COLUMN csrf_tokens.id IS 'Unique identifier for the CSRF token.';
+COMMENT ON COLUMN csrf_tokens.token_hash IS 'Hashed version of the CSRF token for secure storage.';
+COMMENT ON COLUMN csrf_tokens.user_id IS 'Foreign key referencing the user this token is associated with (can be NULL for anonymous users).';
+COMMENT ON COLUMN csrf_tokens.expires_at IS 'Timestamp when the CSRF token expires.';
+COMMENT ON COLUMN csrf_tokens.is_used IS 'Flag indicating if the token has already been used.';
+COMMENT ON COLUMN csrf_tokens.used_at IS 'Timestamp when the token was used.';
+COMMENT ON COLUMN csrf_tokens.session_id IS 'Optional session identifier to bind the token to a specific session.';
+COMMENT ON COLUMN csrf_tokens.ip_address IS 'IP address from which the token was generated.';
+COMMENT ON COLUMN csrf_tokens.created_at IS 'Timestamp of when the CSRF token was created.';

--- a/migrations/025-create-audit-logs-table.sql
+++ b/migrations/025-create-audit-logs-table.sql
@@ -1,0 +1,55 @@
+-- Create audit_logs table
+-- Records significant events and actions within the system for security and compliance.
+-- Tracks user actions, system events, and changes to critical data.
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL, -- User who performed the action (NULL if system event)
+
+    -- Event details
+    event_type VARCHAR(50) NOT NULL,        -- e.g., 'login', 'user_created', 'role_assigned'
+    event_category VARCHAR(30) NOT NULL,   -- e.g., 'auth', 'user_mgmt', 'security'
+    event_description TEXT NOT NULL,
+
+    -- Result and status
+    result VARCHAR(20) NOT NULL CHECK (result IN ('success', 'failure', 'error')),
+    error_message TEXT,
+
+    -- Context information
+    ip_address VARCHAR(45),    -- Supports IPv6
+    user_agent TEXT,
+    request_id VARCHAR(100),   -- Correlation ID for tracing requests
+
+    -- Target resource (what was affected by the event)
+    target_type VARCHAR(50),   -- e.g., 'user', 'role', 'permission'
+    target_id VARCHAR(100),    -- ID of the affected resource
+    target_details TEXT,       -- JSON or structured text with details of the change or event
+
+    -- Timing
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for performance and common queries
+CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user_event ON audit_logs (user_id, event_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_event_category ON audit_logs (event_category, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_target ON audit_logs (target_type, target_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_ip_created ON audit_logs (ip_address, created_at DESC);
+
+
+-- Comments for clarity
+COMMENT ON TABLE audit_logs IS 'Records significant system events and user actions for security, compliance, and debugging.';
+COMMENT ON COLUMN audit_logs.id IS 'Unique identifier for the audit log entry.';
+COMMENT ON COLUMN audit_logs.user_id IS 'Foreign key referencing the user who performed the action (NULL for system events).';
+COMMENT ON COLUMN audit_logs.event_type IS 'Type of event that occurred (e.g., login, user_created, data_exported).';
+COMMENT ON COLUMN audit_logs.event_category IS 'Category of the event (e.g., auth, user_mgmt, security, system).';
+COMMENT ON COLUMN audit_logs.event_description IS 'Detailed description of the event.';
+COMMENT ON COLUMN audit_logs.result IS 'Outcome of the event (success, failure, error).';
+COMMENT ON COLUMN audit_logs.error_message IS 'Error message if the event resulted in a failure or error.';
+COMMENT ON COLUMN audit_logs.ip_address IS 'IP address associated with the event.';
+COMMENT ON COLUMN audit_logs.user_agent IS 'User agent string of the client that initiated the event.';
+COMMENT ON COLUMN audit_logs.request_id IS 'Optional request or correlation ID for tracing related events.';
+COMMENT ON COLUMN audit_logs.target_type IS 'Type of the resource affected by the event (e.g., user, role).';
+COMMENT ON COLUMN audit_logs.target_id IS 'Identifier of the affected resource.';
+COMMENT ON COLUMN audit_logs.target_details IS 'Additional details about the event or changes made (e.g., JSON diff).';
+COMMENT ON COLUMN audit_logs.created_at IS 'Timestamp of when the event was logged.';

--- a/migrations/026-insert-default-roles.sql
+++ b/migrations/026-insert-default-roles.sql
@@ -1,0 +1,24 @@
+-- Insert default roles
+-- Populates the 'roles' table with essential system roles.
+-- These roles are marked as 'is_system = TRUE' to protect them from accidental deletion.
+
+-- Begin transaction
+BEGIN;
+
+-- Define default roles
+-- Note: UUIDs are hardcoded to ensure consistency across environments if needed for direct reference.
+-- Alternatively, use `gen_random_uuid()` if specific UUIDs are not required for system logic.
+
+INSERT INTO roles (id, name, display_name, description, is_system, is_active)
+VALUES
+    (gen_random_uuid(), 'superadmin', 'Super Administrator', 'Has all permissions and manages the entire system. Highest level of access.', TRUE, TRUE),
+    (gen_random_uuid(), 'admin', 'Administrator', 'Manages users, roles, and system settings. High level of access, but less than Super Admin.', TRUE, TRUE),
+    (gen_random_uuid(), 'user', 'Standard User', 'Regular user with basic access to application features. Limited permissions.', TRUE, TRUE),
+    (gen_random_uuid(), 'auditor', 'Auditor', 'Read-only access to logs and system configurations for auditing purposes.', TRUE, TRUE)
+ON CONFLICT (name) DO NOTHING; -- Avoid errors if roles already exist
+
+-- Commit transaction
+COMMIT;
+
+-- Comments for clarity
+COMMENT ON TABLE roles IS 'Stores user roles for role-based access control (RBAC). Default roles are critical for system operation.';

--- a/migrations/027-insert-default-permissions.sql
+++ b/migrations/027-insert-default-permissions.sql
@@ -1,0 +1,64 @@
+-- Insert default permissions
+-- Populates the 'permissions' table with a comprehensive set of system permissions.
+-- These permissions are categorized by resource and action, and marked as 'is_system = TRUE'.
+
+-- Begin transaction
+BEGIN;
+
+-- Define default permissions
+-- Format: resource.action
+-- These permissions cover common CRUD operations and specific application features.
+
+INSERT INTO permissions (name, resource, action, description, is_system, is_active)
+VALUES
+    -- User Management
+    ('user.create', 'user', 'create', 'Allows creating new users.', TRUE, TRUE),
+    ('user.read', 'user', 'read', 'Allows viewing user profiles and information.', TRUE, TRUE),
+    ('user.update', 'user', 'update', 'Allows editing user details (excluding roles/permissions).', TRUE, TRUE),
+    ('user.delete', 'user', 'delete', 'Allows deleting users.', TRUE, TRUE),
+    ('user.manage_roles', 'user', 'manage_roles', 'Allows assigning and revoking roles for users.', TRUE, TRUE),
+    ('user.manage_status', 'user', 'manage_status', 'Allows activating, deactivating, or suspending user accounts.', TRUE, TRUE),
+    ('user.list', 'user', 'list', 'Allows listing all users.', TRUE, TRUE),
+
+    -- Role Management
+    ('role.create', 'role', 'create', 'Allows creating new roles.', TRUE, TRUE),
+    ('role.read', 'role', 'read', 'Allows viewing role details and assigned permissions.', TRUE, TRUE),
+    ('role.update', 'role', 'update', 'Allows editing role details (name, description).', TRUE, TRUE),
+    ('role.delete', 'role', 'delete', 'Allows deleting non-system roles.', TRUE, TRUE),
+    ('role.manage_permissions', 'role', 'manage_permissions', 'Allows assigning and revoking permissions for roles.', TRUE, TRUE),
+    ('role.list', 'role', 'list', 'Allows listing all roles.', TRUE, TRUE),
+
+    -- Permission Management (typically for SuperAdmin only)
+    ('permission.create', 'permission', 'create', 'Allows creating new permissions (rarely used, mostly system-defined).', TRUE, TRUE),
+    ('permission.read', 'permission', 'read', 'Allows viewing permission details.', TRUE, TRUE),
+    ('permission.update', 'permission', 'update', 'Allows editing permission details (rarely used).', TRUE, TRUE),
+    ('permission.delete', 'permission', 'delete', 'Allows deleting non-system permissions (rarely used).', TRUE, TRUE),
+    ('permission.list', 'permission', 'list', 'Allows listing all permissions.', TRUE, TRUE),
+
+    -- Authentication & Session Management
+    ('auth.manage_sessions', 'auth', 'manage_sessions', 'Allows viewing and revoking active user sessions/refresh tokens.', TRUE, TRUE),
+    ('auth.impersonate', 'auth', 'impersonate', 'Allows logging in as another user (for support/troubleshooting).', TRUE, TRUE),
+
+    -- Audit Log Management
+    ('auditlog.read', 'auditlog', 'read', 'Allows viewing audit logs.', TRUE, TRUE),
+    ('auditlog.export', 'auditlog', 'export', 'Allows exporting audit logs.', TRUE, TRUE),
+
+    -- System Settings / Configuration
+    ('system.read_settings', 'system', 'read_settings', 'Allows viewing system configuration settings.', TRUE, TRUE),
+    ('system.update_settings', 'system', 'update_settings', 'Allows modifying system configuration settings.', TRUE, TRUE),
+
+    -- Dashboard Access (Example - tailor to your application)
+    ('dashboard.view_main', 'dashboard', 'view_main', 'Allows viewing the main dashboard.', TRUE, TRUE),
+    ('dashboard.view_analytics', 'dashboard', 'view_analytics', 'Allows viewing the analytics dashboard.', TRUE, TRUE),
+
+    -- Report Access (Example - tailor to your application)
+    ('report.generate_user_activity', 'report', 'generate_user_activity', 'Allows generating user activity reports.', TRUE, TRUE),
+    ('report.view_financials', 'report', 'view_financials', 'Allows viewing financial reports.', TRUE, TRUE)
+
+ON CONFLICT (name) DO NOTHING; -- Avoid errors if permissions already exist
+
+-- Commit transaction
+COMMIT;
+
+-- Comments for clarity
+COMMENT ON TABLE permissions IS 'Stores granular permissions. Default permissions are critical for system operation.';

--- a/migrations/028-assign-default-permissions-to-roles.sql
+++ b/migrations/028-assign-default-permissions-to-roles.sql
@@ -1,0 +1,93 @@
+-- Assign default permissions to roles
+-- Populates the 'role_permissions' table to link predefined roles with their respective permissions.
+-- This script assumes that default roles and permissions have already been inserted by previous migrations.
+
+-- Begin transaction
+BEGIN;
+
+-- Helper function to get role_id by name
+CREATE OR REPLACE FUNCTION get_role_id_by_name(role_name_param VARCHAR(50))
+RETURNS UUID AS $$
+DECLARE
+    role_uuid UUID;
+BEGIN
+    SELECT id INTO role_uuid FROM roles WHERE name = role_name_param;
+    IF role_uuid IS NULL THEN
+        RAISE EXCEPTION 'Role with name % not found.', role_name_param;
+    END IF;
+    RETURN role_uuid;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Helper function to get permission_id by name
+CREATE OR REPLACE FUNCTION get_permission_id_by_name(permission_name_param VARCHAR(100))
+RETURNS UUID AS $$
+DECLARE
+    permission_uuid UUID;
+BEGIN
+    SELECT id INTO permission_uuid FROM permissions WHERE name = permission_name_param;
+    IF permission_uuid IS NULL THEN
+        RAISE EXCEPTION 'Permission with name % not found.', permission_name_param;
+    END IF;
+    RETURN permission_uuid;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Superadmin: Assign all permissions
+-- This is a simplified approach. In a real scenario, you might explicitly list them or use a wildcard if supported.
+-- For this example, we will insert all known permissions.
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT get_role_id_by_name('superadmin'), p.id
+FROM permissions p
+ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+-- Admin: Assign a broad set of permissions, excluding highly sensitive superadmin tasks
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT get_role_id_by_name('admin'), get_permission_id_by_name(p_name)
+FROM (VALUES
+    ('user.create'), ('user.read'), ('user.update'), ('user.delete'),
+    ('user.manage_roles'), ('user.manage_status'), ('user.list'),
+    ('role.create'), ('role.read'), ('role.update'), ('role.delete'),
+    ('role.manage_permissions'), ('role.list'),
+    ('permission.read'), ('permission.list'), -- Admins can see permissions but not usually manage them
+    ('auth.manage_sessions'),
+    ('auditlog.read'), ('auditlog.export'),
+    ('system.read_settings'), ('system.update_settings'),
+    ('dashboard.view_main'), ('dashboard.view_analytics'),
+    ('report.generate_user_activity'), ('report.view_financials')
+) AS perms(p_name)
+ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+-- Standard User: Assign basic application access permissions
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT get_role_id_by_name('user'), get_permission_id_by_name(p_name)
+FROM (VALUES
+    ('user.read'), -- Typically can read their own profile
+    ('dashboard.view_main')
+    -- Add other basic permissions relevant to a standard user
+) AS perms(p_name)
+ON CONFLICT (role_id, permission_id) DO NOTHING;
+-- Note: 'user.read' for a standard user might be restricted by application logic to only their own data.
+
+-- Auditor: Assign read-only access to relevant areas
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT get_role_id_by_name('auditor'), get_permission_id_by_name(p_name)
+FROM (VALUES
+    ('user.read'), ('user.list'),
+    ('role.read'), ('role.list'),
+    ('permission.read'), ('permission.list'),
+    ('auditlog.read'), ('auditlog.export'),
+    ('system.read_settings')
+) AS perms(p_name)
+ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+
+-- Clean up helper functions if they are not needed elsewhere
+DROP FUNCTION IF EXISTS get_role_id_by_name(VARCHAR(50));
+DROP FUNCTION IF EXISTS get_permission_id_by_name(VARCHAR(100));
+
+-- Commit transaction
+COMMIT;
+
+-- Comments for clarity
+COMMENT ON TABLE role_permissions IS 'Association table linking roles to permissions. This migration populates it with default assignments.';


### PR DESCRIPTION
This commit introduces a comprehensive set of yoyo SQL migrations for the authentication and authorization system.

Includes:
- Table creation scripts for users, roles, permissions, role_permissions, refresh_tokens, csrf_tokens, and audit_logs.
- Index creation for performance optimization.
- Foreign key constraints for data integrity.
- Default data insertion for system roles (superadmin, admin, user, auditor) and a granular set of permissions.
- Assignment of default permissions to the predefined roles.
- Comments and `IF NOT EXISTS` clauses for robustness and clarity.

These migrations establish the necessary database schema for the application's authentication features, aligning with the SQLAlchemy models defined in `app/auth/models.py`.